### PR TITLE
remove InfoInhibitor from alertmanager

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -91,12 +91,6 @@ kube-prometheus-stack:
           equal:
             - 'namespace'
             - 'alertname'
-        - source_matchers:
-            - 'alertname = InfoInhibitor'
-          target_matchers:
-            - 'severity = info'
-          equal:
-            - 'namespace'
       route:
         group_by: ['namespace']
         group_wait: 30s


### PR DESCRIPTION
We see this out of order samples in context with infoinhibator:

```
ts=2023-07-07T09:40:55.836Z caller=scrape.go:1645 level=debug component="scrape manager" scrape_pool=federate target="http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9091/federate?match%5B%5D=%7B__name__%3D~%22.%2B%22%7D" msg="Out of order sample" series="ALERTS_FOR_STATE{alertname=\"InfoInhibitor\",alertstate=\"pending\",cluster_id=\"c-xxxx\",container=\"kube-state-metrics\",endpoint=\"http\",namespace=\"demo-logging\",pod=\"rancher-monitoring-kube-state-metrics-7645966d4b-ntwhh\",resource=\"requests.storage\",resourcequota=\"default-djrxd\",service=\"rancher-monitoring-kube-state-metrics\",severity=\"none\",cluster=\"t02\",instance=\"\",prometheus=\"cattle-monitoring-system/rancher-monitoring-prometheus\",prometheus_replica=\"prometheus-rancher-monitoring-prometheus-0\"}"
```