### PR TITLE
Fix link in readme to app-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Evolution of Rancher Monitoring V1/V2. We call it: V3
 
-Please read the [Application Readme](https://gitlab.devops.telekom.de/caas/helm-charts/caas-project-monitoring/-/blob/main/app-readme.md) for more details.
+Please read the [Application Readme](app-readme.md) for more details.
 
 ## Installation via Helm
 


### PR DESCRIPTION
This pr fixes a link in the app-readme, which was previously hardcoded to the internal gitlab. It is now a relative link