### PR TITLE
Fix/16 rbac

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
 #  catalog.cattle.io/certified: rancher
 name: caas-project-monitoring
 description: A Helm chart for Rancher Project Monitoring V3
-version: 1.0.17
+version: 1.0.18
 appVersion: "40.1.2"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/templates/caas-project-monitoring-rbac.yaml
+++ b/templates/caas-project-monitoring-rbac.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.caas.rbac.enabled }}
 {{ $fullname := include "caas-project-monitoring.fullname" . }}
 {{ $serviceaccount := include "caas-project-monitoring.serviceAccountName" . }}
-{{ $monitornamespaces := include "caas-project-monitoring.namespace" . }}
+{{ $monitornamespaces := .Release.Namespace }}
 {{ if .Values.caas.projectNamespaces }}
 {{ $monitornamespaces = printf "%s %s" $monitornamespaces .Values.caas.projectNamespaces }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -10,7 +10,7 @@ caas:
       name: project-monitoring
   # list of additional namespaces where project-monitoring should watch
   #projectNamespaces: 
-  #projectNamespaces: demoapp3,demoapp4
+  #projectNamespaces: demoapp3 demoapp4
   #
   # deploy additional nginx.conf and dashboard for Grafana
   grafana:


### PR DESCRIPTION
in 1.0.16 the roles/roleBindings for additional namespaces is missing so no scrap of additional serviceMonitor is possible