### PR TITLE
set sub_filter_once on to prevent 404 on Grafana navigation

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   catalog.cattle.io/requests-memory: 1000Mi
 name: caas-project-monitoring
 description: A Helm chart for Rancher Project Monitoring V3
-version: 1.1.0
+version: 1.2.0
 appVersion: "51.0.3"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/templates/grafana-nginx-config.yaml
+++ b/templates/grafana-nginx-config.yaml
@@ -54,7 +54,7 @@ data:
           proxy_pass     http://localhost:3000;
 
           sub_filter_types application/json;
-          sub_filter_once off;
+          sub_filter_once on;
           sub_filter '"url":"/d' '"url":"d';
         }
 
@@ -77,7 +77,7 @@ data:
           
           proxy_pass     http://localhost:3000/;
 
-          sub_filter_once off;
+          sub_filter_once on;
 {{- if not (empty .Values.global.cattle.clusterId) }}
           sub_filter '"appSubUrl":""' '"appSubUrl":"/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ $releasenamespace }}/services/http:project-monitoring-grafana:80/proxy"';
 {{- else }}

--- a/values.yaml
+++ b/values.yaml
@@ -530,7 +530,7 @@ kube-prometheus-stack:
         level: info
     image:
       repository: mtr.devops.telekom.de/kubeprometheusstack/grafana
-      tag: 9.1.5
+      tag: 10.1.4
     namespaceOverride: ""
     nameOverride: project-monitoring-grafana
     rbac:


### PR DESCRIPTION
ref: 

- https://github.com/grafana/grafana/issues/75331
- http://nginx.org/en/docs/http/ngx_http_sub_module.html#sub_filter_once
- https://github.com/rancher/charts/blob/dev-v2.8/charts/rancher-monitoring/102.0.2%2Bup40.1.2/charts/grafana/templates/nginx-config.yaml#L76

if sub_filter_once is set off Grafana navigation is broken on the first click("home", "dashboards","login"). After refresh the page the navigation and the target page works.

