### PR TITLE
Prevent KubeletDown alerts on custom project monitoring setup

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   catalog.cattle.io/requests-memory: 1000Mi
 name: caas-project-monitoring
 description: A Helm chart for Rancher Project Monitoring V3
-version: 1.2.1
+version: "1.2.2"
 appVersion: "51.0.3"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -103,7 +103,8 @@ kube-prometheus-stack:
     appNamespacesTarget: ".*"
     runbookUrl: "https://runbooks.prometheus-operator.dev/runbooks"
     ## Disabled PrometheusRule alerts
-    disabled: {}
+    disabled:
+      KubeletDown: true
     # KubeAPIDown: true
     # NodeRAIDDegraded: true
   ## Provide custom recording or alerting rules to be deployed into the cluster.


### PR DESCRIPTION
Default monitoring setup for CaaS projects  shows "KuebeletDown" alerts in alertmanager. @eumel8  we spoke abot that in chat.
To prevent that, the KubeletDown alert should be disabled by default, which is prepared with this change.
