### PR TITLE
fix outOfOrderTimeWindow value

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -664,7 +664,7 @@ kube-prometheus-stack:
       additionalRemoteWrite: []
       additionalScrapeConfigs:
         - job_name: "federate"
-          scrape_interval: 10s
+          scrape_interval: 60s
           honor_labels: true
           metrics_path: "/federate"
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -778,7 +778,7 @@ kube-prometheus-stack:
       #  emptyDir:
       #    medium: Memory
       tsdb:
-        outOfOrderTimeWindow: 5s
+        outOfOrderTimeWindow: 0s
       volumes: []
       volumeMounts: []
       walCompression: true


### PR DESCRIPTION
With this `outOfOrderTimeWindow:5s` we experienced Federator Target down with error `sample too old`.
Investigated this error also in this issue https://github.com/prometheus/prometheus/issues/11602, which brings me to this setting of `outOfOrderTimeWindow:60m` (1h!!!). With that Federator Target is up and metrics have no dropouts anymore.

Nevertheless the `scrape_interval`was 10s, which is more or less useless if Kubelet Cluster metrics are only scraped each 30s. So let's change the default value for federate to 60s. This can be overwritten, of course.