### PR TITLE
chore: deprecate Rancher Workload dashboards

### DIFF
--- a/files/rancher-workload-pods.json
+++ b/files/rancher-workload-pods.json
@@ -94,7 +94,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Utilization",
+      "title": "CPU Utilization (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -189,7 +189,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Memory Utilization",
+      "title": "Memory Utilization (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -314,7 +314,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Network Traffic",
+      "title": "Network Traffic (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -415,7 +415,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Network I/O",
+      "title": "Network I/O (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -516,7 +516,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Disk I/O",
+      "title": "Disk I/O (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -569,9 +569,7 @@
         "hide": 0,
         "label": "Data Source",
         "name": "datasource",
-        "options": [
-
-        ],
+        "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",

--- a/files/rancher-workload-pods.json
+++ b/files/rancher-workload-pods.json
@@ -646,7 +646,7 @@
     ]
   },
   "timezone": "",
-  "title": "Rancher / Workload (Pods)",
+  "title": "Rancher / Workload (Pods) (deprecated)",
   "uid": "rancher-workload-pods-1",
   "version": 8
 }

--- a/files/rancher-workload.json
+++ b/files/rancher-workload.json
@@ -646,7 +646,7 @@
     ]
   },
   "timezone": "",
-  "title": "Rancher / Workload",
+  "title": "Rancher / Workload (deprecated)",
   "uid": "rancher-workload-1",
   "version": 8
 }

--- a/files/rancher-workload.json
+++ b/files/rancher-workload.json
@@ -94,7 +94,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Utilization",
+      "title": "CPU Utilization (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -189,7 +189,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Memory Utilization",
+      "title": "Memory Utilization (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -314,7 +314,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Network Traffic",
+      "title": "Network Traffic (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -415,7 +415,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Network I/O",
+      "title": "Network I/O (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -516,7 +516,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Disk I/O",
+      "title": "Disk I/O (deprecated)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -569,9 +569,7 @@
         "hide": 0,
         "label": "Data Source",
         "name": "datasource",
-        "options": [
-
-        ],
+        "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",


### PR DESCRIPTION
## Motivation

The Rancher Workload Charts do not calculate the charts properly.

E.g. the `container_memory_working_set_bytes` is containing multiple metrics that need to be filtered to show the consumed amount of memory in the namespace by workload.
Rancher did not update the dashboards yet. Users are able to use the kube-metics dashboards instead of the Rancher dashboards. The dashboards are not maintained by us.

## Changes

- see the commit history