### PR TITLE
Dashboard for Project Logging

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   catalog.cattle.io/requests-memory: 1000Mi
 name: caas-project-monitoring
 description: A Helm chart for Rancher Project Monitoring V3
-version: "1.2.8"
+version: "1.2.9"
 appVersion: "51.0.3"
 icon: https://raw.githubusercontent.com/caas-team/caas-project-monitoring/main/logo.png
 keywords:

--- a/files/project-logging.json
+++ b/files/project-logging.json
@@ -11,6 +11,14 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "logging"
+          ],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]

--- a/files/project-logging.json
+++ b/files/project-logging.json
@@ -1,0 +1,952 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "This is dashboard for Fluentd in context Project Logging",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 7752,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Aggregated Data",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_info{pod=~\".*fluentd.*\",pod!~\".*config.*\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "title": "Fluentd",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 2,
+        "y": 1
+      },
+      "id": 25,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fluentd_router_records_total[1m]))",
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Fluentd Router records/s",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 7,
+        "y": 1
+      },
+      "id": 32,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fluentd_output_status_emit_records{plugin_id=~\"^(flow|clusterflow):.*:.*:(output|clusteroutput).*:.*$\"}[5m]))",
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Fluentd Output Records",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 19,
+        "x": 0,
+        "y": 3
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.4.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "rate(fluentd_output_status_emit_count{pod=~\"$fluentd\",plugin_id=~\"$fluentdplugin\"}[5m])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{ plugin_id }}/{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Fluentd Records by Plugin",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "cps",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 21,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "fluentd",
+      "type": "row"
+    },
+    {
+      "columns": [],
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 19,
+        "x": 0,
+        "y": 12
+      },
+      "id": 27,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "topk(5, sum(rate(fluentd_router_records_total[1m])) by (flow, id))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Aggregated Fluentd Routes",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.4.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fluentd_output_status_retry_count{pod=~\"$fluentd\",plugin_id=~\"$fluentdplugin\"}[1m])) by (pod)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Retry {{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fluentd_output_status_num_errors{pod=~\"$fluentd\",plugin_id=~\"$fluentdplugin\"}[1m])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Error {{pod}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Fluentd Output Error and Retry",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "cps",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 10,
+        "x": 9,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.4.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "fluentd_output_status_buffer_total_bytes{pod=~\"$fluentd\",plugin_id=~\"$fluentdplugin\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ plugin_id }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "fluentd_output_status_buffer_queue_length{pod=~\"$fluentd\",plugin_id=~\"$fluentdplugin\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Fluentd Output Buffer",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 19,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 42,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.4.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "node_filesystem_size_bytes{pod=~\"$fluentd\",mountpoint=\"/buffers\",endpoint=\"buffer-metrics\", fstype!=\"\"} - node_filesystem_free_bytes{pod=~\"$fluentd\",mountpoint=\"/buffers\",endpoint=\"buffer-metrics\", fstype!=\"\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Used: {{pod}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "node_filesystem_size_bytes{pod=~\"$fluentd\",mountpoint=\"/buffers\",endpoint=\"buffer-metrics\", fstype!=\"\"}",
+          "interval": "",
+          "legendFormat": "Total: {{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Fluentd Buffer Disk",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:419",
+          "format": "bytes",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:420",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "PBFA97CFB590B2093"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(node_cpu_seconds_total, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(node_cpu_seconds_total, cluster)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(fluentd_output_status_emit_records, plugin_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Fluentd Plugin",
+        "multi": true,
+        "name": "fluentdplugin",
+        "options": [],
+        "query": "label_values(fluentd_output_status_emit_records, plugin_id)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(fluentbit_input_bytes_total,pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "fluentbit",
+        "options": [],
+        "query": "label_values(fluentbit_input_bytes_total,pod)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(fluentd_output_status_emit_count,pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "fluentd",
+        "options": [],
+        "query": "label_values(fluentd_output_status_emit_count,pod)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Project Logging Dashboard",
+  "uid": "bNn5LUtizplj2",
+  "version": 1,
+  "weekStart": ""
+}

--- a/files/project-logging.json
+++ b/files/project-logging.json
@@ -805,34 +805,6 @@
       },
       {
         "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(node_cpu_seconds_total, cluster)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(node_cpu_seconds_total, cluster)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 2,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
           "selected": false,
           "text": "All",
           "value": "$__all"
@@ -849,33 +821,6 @@
         "name": "fluentdplugin",
         "options": [],
         "query": "label_values(fluentd_output_status_emit_records, plugin_id)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(fluentbit_input_bytes_total,pod)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "",
-        "multi": true,
-        "name": "fluentbit",
-        "options": [],
-        "query": "label_values(fluentbit_input_bytes_total,pod)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
With the new kube-logging v3 the user becomes fluentd pods deployed together with Services endpoints for metrics and ServiceMonitor. This PR provides a Grafana dashboard based on [Banzaicloud Logging Chart](https://grafana.com/grafana/dashboards/7752-logging-dashboard/) without the Fluentbit part. The Angular backend is marked as deprecated but at the moment we have no other choices.

```
> kubectl -n demoapp2 get services
NAME                                                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
alertmanager-operated                                 ClusterIP   None            <none>        9093/TCP,9094/TCP,9094/UDP   51m
customer-logging-ld7r6-m7cwj-fluentd                  ClusterIP   10.43.211.50    <none>        24240/TCP,24240/UDP          74m
customer-logging-ld7r6-m7cwj-fluentd-buffer-metrics   ClusterIP   None            <none>        9200/TCP                     74m
customer-logging-ld7r6-m7cwj-fluentd-headless         ClusterIP   None            <none>        24240/TCP,24240/UDP          74m
customer-logging-ld7r6-m7cwj-fluentd-metrics          ClusterIP   None            <none>        24231/TCP                    74m

> kubectl -n demoapp2 get servicemonitor
NAME                                                  AGE
customer-logging-ld7r6-m7cwj-fluentd-buffer-metrics   74m
customer-logging-ld7r6-m7cwj-fluentd-metrics          74m
```

<details>

```
# TYPE fluentd_router_records_total counter
# HELP fluentd_router_records_total Total number of events routed for the flow
fluentd_router_records_total{flow="@af7917d155eaa1dc2247446085029c2d",id="flow:demoapp2:log-generator"} 4626.0
# TYPE fluentd_output_status_buffer_total_bytes gauge
# HELP fluentd_output_status_buffer_total_bytes Current total size of stage and queue buffers.
fluentd_output_status_buffer_total_bytes{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 63383.0
fluentd_output_status_buffer_total_bytes{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 18335.0
# TYPE fluentd_output_status_buffer_stage_length gauge
# HELP fluentd_output_status_buffer_stage_length Current length of stage buffers.
fluentd_output_status_buffer_stage_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 30.0
fluentd_output_status_buffer_stage_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 1.0
# TYPE fluentd_output_status_buffer_stage_byte_size gauge
# HELP fluentd_output_status_buffer_stage_byte_size Current total size of stage buffers.
fluentd_output_status_buffer_stage_byte_size{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 63383.0
fluentd_output_status_buffer_stage_byte_size{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 18335.0
# TYPE fluentd_output_status_buffer_queue_length gauge
# HELP fluentd_output_status_buffer_queue_length Current length of queue buffers.
fluentd_output_status_buffer_queue_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 0.0
fluentd_output_status_buffer_queue_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 0.0
# TYPE fluentd_output_status_queue_byte_size gauge
# HELP fluentd_output_status_queue_byte_size Current total size of queue buffers.
fluentd_output_status_queue_byte_size{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 0.0
fluentd_output_status_queue_byte_size{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 0.0
# TYPE fluentd_output_status_buffer_available_space_ratio gauge
# HELP fluentd_output_status_buffer_available_space_ratio Ratio of available space in buffer.
fluentd_output_status_buffer_available_space_ratio{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 100.0
fluentd_output_status_buffer_available_space_ratio{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 100.0
# TYPE fluentd_output_status_buffer_newest_timekey gauge
# HELP fluentd_output_status_buffer_newest_timekey Newest timekey in buffer.
fluentd_output_status_buffer_newest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 1714398150.0
fluentd_output_status_buffer_newest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 1714398000.0
# TYPE fluentd_output_status_buffer_oldest_timekey gauge
# HELP fluentd_output_status_buffer_oldest_timekey Oldest timekey in buffer.
fluentd_output_status_buffer_oldest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 1714398090.0
fluentd_output_status_buffer_oldest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 1714398000.0
# TYPE fluentd_output_status_retry_count gauge
# HELP fluentd_output_status_retry_count Current retry counts.
fluentd_output_status_retry_count{plugin_id="main",type="label_router"} 0.0
fluentd_output_status_retry_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_retry_count{plugin_id="object:794",type="copy"} 485.0
fluentd_output_status_retry_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 399.0
fluentd_output_status_retry_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 86.0
fluentd_output_status_retry_count{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_retry_count{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_num_errors gauge
# HELP fluentd_output_status_num_errors Current number of errors.
fluentd_output_status_num_errors{plugin_id="main",type="label_router"} 0.0
fluentd_output_status_num_errors{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_num_errors{plugin_id="object:794",type="copy"} 485.0
fluentd_output_status_num_errors{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 399.0
fluentd_output_status_num_errors{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 86.0
fluentd_output_status_num_errors{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_num_errors{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_emit_count gauge
# HELP fluentd_output_status_emit_count Current emit counts.
fluentd_output_status_emit_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_emit_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 4623.0
fluentd_output_status_emit_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 4224.0
fluentd_output_status_emit_count{plugin_id="main-fluentd-log",type="null"} 7861.0
fluentd_output_status_emit_count{plugin_id="main-fluentd-error",type="null"} 485.0
# TYPE fluentd_output_status_emit_records gauge
# HELP fluentd_output_status_emit_records Current emit records.
fluentd_output_status_emit_records{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_emit_records{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 4226.0
fluentd_output_status_emit_records{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 4140.0
fluentd_output_status_emit_records{plugin_id="main-fluentd-log",type="null"} 7861.0
fluentd_output_status_emit_records{plugin_id="main-fluentd-error",type="null"} 485.0
# TYPE fluentd_output_status_write_count gauge
# HELP fluentd_output_status_write_count Current write counts.
fluentd_output_status_write_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_write_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 2210.0
fluentd_output_status_write_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 215.0
fluentd_output_status_write_count{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_write_count{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_rollback_count gauge
# HELP fluentd_output_status_rollback_count Current rollback counts.
fluentd_output_status_rollback_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_rollback_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 0.0
fluentd_output_status_rollback_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 0.0
fluentd_output_status_rollback_count{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_rollback_count{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_flush_time_count gauge
# HELP fluentd_output_status_flush_time_count Total flush time.
fluentd_output_status_flush_time_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_flush_time_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 24067.0
fluentd_output_status_flush_time_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 27975.0
fluentd_output_status_flush_time_count{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_flush_time_count{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_slow_flush_count gauge
# HELP fluentd_output_status_slow_flush_count Current slow flush counts.
fluentd_output_status_slow_flush_count{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_slow_flush_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 0.0
fluentd_output_status_slow_flush_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 0.0
fluentd_output_status_slow_flush_count{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_slow_flush_count{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_output_status_retry_wait gauge
# HELP fluentd_output_status_retry_wait Current retry wait
fluentd_output_status_retry_wait{plugin_id="main-no-output",type="null"} 0.0
fluentd_output_status_retry_wait{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",type="http"} 0.0
fluentd_output_status_retry_wait{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",type="elasticsearch_data_stream"} 0.0
fluentd_output_status_retry_wait{plugin_id="main-fluentd-log",type="null"} 0.0
fluentd_output_status_retry_wait{plugin_id="main-fluentd-error",type="null"} 0.0
# TYPE fluentd_status_buffer_newest_timekey gauge
# HELP fluentd_status_buffer_newest_timekey Newest timekey in buffer.
fluentd_status_buffer_newest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",plugin_category="output",type="http"} 1714398150.0
fluentd_status_buffer_newest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",plugin_category="output",type="elasticsearch_data_stream"} 1714398000.0
# TYPE fluentd_status_buffer_oldest_timekey gauge
# HELP fluentd_status_buffer_oldest_timekey Oldest timekey in buffer.
fluentd_status_buffer_oldest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",plugin_category="output",type="http"} 1714398090.0
fluentd_status_buffer_oldest_timekey{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",plugin_category="output",type="elasticsearch_data_stream"} 1714398000.0
# TYPE fluentd_status_buffer_queue_length gauge
# HELP fluentd_status_buffer_queue_length Current buffer queue length.
fluentd_status_buffer_queue_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",plugin_category="output",type="http"} 0.0
fluentd_status_buffer_queue_length{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",plugin_category="output",type="elasticsearch_data_stream"} 0.0
# TYPE fluentd_status_buffer_total_bytes gauge
# HELP fluentd_status_buffer_total_bytes Current total size of queued buffers.
fluentd_status_buffer_total_bytes{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",plugin_category="output",type="http"} 63383.0
fluentd_status_buffer_total_bytes{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",plugin_category="output",type="elasticsearch_data_stream"} 18335.0
# TYPE fluentd_status_retry_count gauge
# HELP fluentd_status_retry_count Current retry counts.
fluentd_status_retry_count{plugin_id="main",plugin_category="output",type="label_router"} 0.0
fluentd_status_retry_count{plugin_id="main-no-output",plugin_category="output",type="null"} 0.0
fluentd_status_retry_count{plugin_id="object:794",plugin_category="output",type="copy"} 485.0
fluentd_status_retry_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:http",plugin_category="output",type="http"} 399.0
fluentd_status_retry_count{plugin_id="flow:demoapp2:log-generator:output:demoapp2:dispaas-cms",plugin_category="output",type="elasticsearch_data_stream"} 86.0
fluentd_status_retry_count{plugin_id="main-fluentd-log",plugin_category="output",type="null"} 0.0
fluentd_status_retry_count{plugin_id="main-fluentd-error",plugin_category="output",type="null"} 0.0
```

```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 7
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.20.4"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 839656
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 839656
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.44524e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 397
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 7.189936e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 839656
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 1.736704e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 2.097152e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 6073
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 1.736704e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 3.833856e+06
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 0
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 6470
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 1200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 36800
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 48960
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 4.194304e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 734640
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 360448
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 360448
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 1.362868e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 6
# HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which node_exporter was built, and the goos and goarch for the build.
# TYPE node_exporter_build_info gauge
node_exporter_build_info{branch="master",goarch="amd64",goos="linux",goversion="go1.20.4",revision="8c5847bd9427c67bc1845c6cbf9dd5c7eaa1cc79",tags="netgo osusergo static_build",version="1.5.0"} 1
# HELP node_filesystem_avail_bytes Filesystem space available to non-root users in bytes.
# TYPE node_filesystem_avail_bytes gauge
node_filesystem_avail_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 8.5573750784e+10
node_filesystem_avail_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 8.5573750784e+10
node_filesystem_avail_bytes{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 4.9808375808e+10
node_filesystem_avail_bytes{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 1.3345378304e+10
node_filesystem_avail_bytes{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 9.223372020556759e+18
# HELP node_filesystem_device_error Whether an error occurred while getting statistics for the given device.
# TYPE node_filesystem_device_error gauge
node_filesystem_device_error{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 0
node_filesystem_device_error{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 0
node_filesystem_device_error{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 0
node_filesystem_device_error{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 0
node_filesystem_device_error{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 0
# HELP node_filesystem_files Filesystem total file nodes.
# TYPE node_filesystem_files gauge
node_filesystem_files{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 6.5536e+06
node_filesystem_files{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 6.5536e+06
node_filesystem_files{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 3.2768e+06
node_filesystem_files{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 2.022292e+06
node_filesystem_files{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 0
# HELP node_filesystem_files_free Filesystem total free file nodes.
# TYPE node_filesystem_files_free gauge
node_filesystem_files_free{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 6.245805e+06
node_filesystem_files_free{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 6.245805e+06
node_filesystem_files_free{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 3.275583e+06
node_filesystem_files_free{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 2.022283e+06
node_filesystem_files_free{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 0
# HELP node_filesystem_free_bytes Filesystem free space in bytes.
# TYPE node_filesystem_free_bytes gauge
node_filesystem_free_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 9.0959183872e+10
node_filesystem_free_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 9.0959183872e+10
node_filesystem_free_bytes{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 5.2509454336e+10
node_filesystem_free_bytes{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 1.3345378304e+10
node_filesystem_free_bytes{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 9.223372020556759e+18
# HELP node_filesystem_readonly Filesystem read-only status.
# TYPE node_filesystem_readonly gauge
node_filesystem_readonly{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 1
node_filesystem_readonly{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 1
node_filesystem_readonly{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 0
node_filesystem_readonly{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 1
node_filesystem_readonly{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 0
# HELP node_filesystem_size_bytes Filesystem size in bytes.
# TYPE node_filesystem_size_bytes gauge
node_filesystem_size_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/hostname"} 1.05088212992e+11
node_filesystem_size_bytes{device="/dev/nvme1n1p1",fstype="ext4",mountpoint="/etc/resolv.conf"} 1.05088212992e+11
node_filesystem_size_bytes{device="/dev/nvme2n1p1",fstype="ext4",mountpoint="/etc/hosts"} 5.2520517632e+10
node_filesystem_size_bytes{device="tmpfs",fstype="tmpfs",mountpoint="/var/run/secrets/kubernetes.io/serviceaccount"} 1.3345390592e+10
node_filesystem_size_bytes{device="worker-shared-pv.caas-infra-s02.aws.telekom.de:/demoapp2-customer-logging-ld7r6-m7cwj-fluentd-buffer-customer-logging-ld7r6-m7cwj-fluentd-0-pvc-f83a7825-25bc-4ca2-8c3f-f0a74561a9f8",fstype="nfs4",mountpoint="/buffers"} 9.223372036853727e+18
# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
# TYPE node_scrape_collector_duration_seconds gauge
node_scrape_collector_duration_seconds{collector="filesystem"} 0.001507844
node_scrape_collector_duration_seconds{collector="textfile"} 0.000129832
# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
# TYPE node_scrape_collector_success gauge
node_scrape_collector_success{collector="filesystem"} 1
node_scrape_collector_success{collector="textfile"} 1
# HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
# TYPE node_textfile_scrape_error gauge
node_textfile_scrape_error 0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 131072
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 8
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.376256e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.7143935263e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 7.41941248e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
# TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```
</details>