### PR TITLE
fix: fixing kubeprometheusstack/prometheus tag version number

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -695,7 +695,7 @@ kube-prometheus-stack:
       image:
         registry: mtr.devops.telekom.de
         repository: kubeprometheusstack/prometheus
-        tag: v2.50.1
+        tag: v2.51.2
       ignoreNamespaceSelectors: false
       listenLocal: false
       logFormat: logfmt


### PR DESCRIPTION
Kubeprometheusstack/prometheus v2.50.1 does not exists in MTR. v2.51.2 exists so changing the tag to v2.51.2