### PR TITLE
Create PVC for Prometheus data by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -766,7 +766,14 @@ kube-prometheus-stack:
       #  matchLabels:
       #    "field.cattle.io/projectId": *projectId
       shards: 1
-      storageSpec: {}
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 50Gi
+          selector: {}
       ## Using PersistentVolumeClaim
       ##
       #  volumeClaimTemplate:


### PR DESCRIPTION
The Chart uses by default an emptyDir to store the Prometheus data.

This PR will change that behavior to use an 50Gi sized PVC instead of an emptyDir.