### PR TITLE
feat: exclude ingress-nginx metrics from federation endpoint

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -313,7 +313,7 @@ kube-prometheus-stack:
         params:
           "match[]":
           # Scrape all metrics except of ingress controller metrics (default)
-          - '{__name__=~".+", job!="ingress-nginx"}' # Excluded due increasing amout of metrics in case multiple Ingress resources defined in scraped namespaces
+          - '{__name__=~".+", job!="ingress-nginx"}' # Excluded due to increasing amount of metrics when multiple Ingress resources are defined in scraped namespaces
       evaluationInterval: "30s"
       image:
         registry: mtr.devops.telekom.de


### PR DESCRIPTION
**Major Change to default federation configuration**

## Summary
- Added filter to federation scrape job configuration to exclude metrics with `job="ingress-nginx"` label
- Modified the `match[]` parameter in the federation endpoint to use `{__name__=~".+",job!="ingress-nginx"}`

## Test plan
- [x] Deploy the updated configuration to a test environment
- [x] Verify that ingress-nginx metrics are not being scraped via the federation endpoint
- [x] Confirm that other metrics are still being scraped correctly